### PR TITLE
Authenticate each request

### DIFF
--- a/lib/grape_devise_token_auth/auth_headers.rb
+++ b/lib/grape_devise_token_auth/auth_headers.rb
@@ -2,8 +2,8 @@ module GrapeDeviseTokenAuth
   class AuthHeaders
     extend Forwardable
 
-    def initialize(warden, mapping, request_start, data)
-      @resource = warden.session_serializer.fetch(mapping)
+    def initialize(resource, request_start, data)
+      @resource = resource
       @request_start = request_start
       @data = data
     end

--- a/lib/grape_devise_token_auth/auth_helpers.rb
+++ b/lib/grape_devise_token_auth/auth_helpers.rb
@@ -3,7 +3,8 @@ module GrapeDeviseTokenAuth
     def self.included(_base)
       Devise.mappings.keys.each do |mapping|
         define_method("current_#{mapping}") do
-          warden.session_serializer.fetch(mapping)
+          user = send("authenticate_#{mapping}")
+          user
         end
 
         define_method("authenticate_#{mapping}") do
@@ -12,7 +13,6 @@ module GrapeDeviseTokenAuth
           token_authorizer = TokenAuthorizer.new(authorizer_data,
                                                  devise_interface)
           user = token_authorizer.authenticate_from_token(mapping)
-          devise_interface.set_user_in_warden(mapping, user) if user
           user
         end
 
@@ -22,10 +22,6 @@ module GrapeDeviseTokenAuth
           user
         end
       end
-    end
-
-    def warden
-      @warden ||= env['warden']
     end
 
     def authenticated?(scope = :user)

--- a/lib/grape_devise_token_auth/devise_interface.rb
+++ b/lib/grape_devise_token_auth/devise_interface.rb
@@ -1,31 +1,12 @@
 module GrapeDeviseTokenAuth
   class DeviseInterface
     def initialize(data)
-      @warden = data.warden
       @client_id = data.client_id
-    end
-
-    # extracted and simplified from Devise
-    def set_user_in_warden(scope, resource)
-      scope = Devise::Mapping.find_scope!(scope)
-      warden.session_serializer.store(resource, scope)
     end
 
     def mapping_to_class(m)
       mapping = m ? Devise.mappings[m] : Devise.mappings.values.first
       @resource_class = mapping.to
     end
-
-    def exisiting_warden_user(resource_class)
-      warden_user =  warden.user(resource_class.to_s.underscore.to_sym)
-      return unless warden_user && warden_user.tokens[@client_id].nil?
-      resource = warden_user
-      resource.create_new_auth_token
-      resource
-    end
-
-    private
-
-    attr_reader :warden
   end
 end

--- a/lib/grape_devise_token_auth/middleware.rb
+++ b/lib/grape_devise_token_auth/middleware.rb
@@ -23,8 +23,8 @@ module GrapeDeviseTokenAuth
     def_delegators :@authorizer_data, :warden, :token, :client_id
 
     def auth_all
-      return if skip_auth_all?
       @resource = token_authorizer.authenticate_from_token(@resource_name)
+      return if skip_auth_all?
       fail Unauthorized unless user
     end
 

--- a/lib/grape_devise_token_auth/middleware.rb
+++ b/lib/grape_devise_token_auth/middleware.rb
@@ -24,9 +24,8 @@ module GrapeDeviseTokenAuth
 
     def auth_all
       return if skip_auth_all?
-      user = token_authorizer.authenticate_from_token(@resource_name)
+      @resource = token_authorizer.authenticate_from_token(@resource_name)
       fail Unauthorized unless user
-      sign_in_user(user)
     end
 
     def skip_auth_all?
@@ -41,12 +40,8 @@ module GrapeDeviseTokenAuth
                                               @devise_interface)
     end
 
-    def sign_in_user(user)
-      @devise_interface.set_user_in_warden(@resource_name, user)
-    end
-
     def responses_with_auth_headers(status, headers, response)
-      auth_headers = AuthHeaders.new(warden, @resource_name, request_start, authorizer_data)
+      auth_headers = AuthHeaders.new(@resource, request_start, authorizer_data)
       [
         status,
         headers.merge(auth_headers.headers),

--- a/lib/grape_devise_token_auth/token_authorizer.rb
+++ b/lib/grape_devise_token_auth/token_authorizer.rb
@@ -8,13 +8,11 @@ module GrapeDeviseTokenAuth
     end
 
     def authenticate_from_token(mapping = nil)
-      @resource_class =  devise_interface.mapping_to_class(mapping)
+      @resource_class = devise_interface.mapping_to_class(mapping)
       return nil unless resource_class
-
       return nil unless data.token_prerequisites_present?
       load_user_from_uid
       return nil unless user_authenticated?
-
       user
     end
 

--- a/lib/grape_devise_token_auth/token_authorizer.rb
+++ b/lib/grape_devise_token_auth/token_authorizer.rb
@@ -11,9 +11,6 @@ module GrapeDeviseTokenAuth
       @resource_class =  devise_interface.mapping_to_class(mapping)
       return nil unless resource_class
 
-      resource_from_existing_devise_user
-      return resource if correct_resource_type_logged_in?
-
       return nil unless data.token_prerequisites_present?
       load_user_from_uid
       return nil unless user_authenticated?
@@ -33,10 +30,6 @@ module GrapeDeviseTokenAuth
 
     def load_user_from_uid
       @user = resource_class.find_by_uid(uid)
-    end
-
-    def resource_from_existing_devise_user
-      @resource = @devise_interface.exisiting_warden_user(resource_class)
     end
 
     def correct_resource_type_logged_in?


### PR DESCRIPTION
Removed warden logic because it caused a change in the headers to not have any effect.

In my example, I am using a Grape endpoint that needs to be available in a "light" version if the user is not logged in and will return more information if the user is logged in.

Thus, I played around with the request headers and noticed that the user is constantly logged in after the first log in, no matter if I changed the request headers or not. Is this the intended behaviour by devise_token_auth, as the "native" devise_token_auth endpoints behave differently?

I therefore removed the warden logic from this gem to authenticate each request by its header parameters individually.

The according issue is #7
