### PR TITLE
merge headers from batch requests

### DIFF
--- a/lib/grape_devise_token_auth/auth_headers.rb
+++ b/lib/grape_devise_token_auth/auth_headers.rb
@@ -25,25 +25,29 @@ module GrapeDeviseTokenAuth
     end
 
     def within_batch_request_window?
-      end_of_window = Time.parse(resource.tokens[client_id]['updated_at']) +
+      end_of_window = Time.parse(resource.tokens[client_id]['updated_at'].to_s) +
                       GrapeDeviseTokenAuth.batch_request_buffer_throttle
 
       request_start < end_of_window
     end
 
     def auth_headers_from_resource
-      auth_headers = {}
-      resource.with_lock do
-        if !GrapeDeviseTokenAuth.change_headers_on_each_request
-          auth_headers = resource.extend_batch_buffer(token, client_id)
-        elsif batch_request?
-          resource.extend_batch_buffer(token, client_id)
-          # don't set any headers in a batch request
-        else
-          auth_headers = resource.create_new_auth_token(client_id)
+      if !GrapeDeviseTokenAuth.change_headers_on_each_request
+        return {} if resource.reload.tokens[client_id].nil?
+        resource.build_auth_header(token, client_id)
+      else
+        resource.with_lock do
+          return {} if resource.tokens[client_id].nil?
+          if batch_request?
+            auth_headers = resource.extend_batch_buffer(token, client_id)
+            auth_headers[DeviseTokenAuth.headers_names[:"access-token"]] = ' '
+            auth_headers[DeviseTokenAuth.headers_names[:"expiry"]] = ' '
+            auth_headers
+          else
+            resource.create_new_auth_token(client_id)
+          end
         end
       end
-      auth_headers
     end
   end
 end

--- a/lib/grape_devise_token_auth/middleware.rb
+++ b/lib/grape_devise_token_auth/middleware.rb
@@ -49,7 +49,7 @@ module GrapeDeviseTokenAuth
       auth_headers = AuthHeaders.new(warden, @resource_name, request_start, authorizer_data)
       [
         status,
-        headers.merge(auth_headers.headers),
+        headers.merge!(auth_headers.headers),
         response
       ]
     end


### PR DESCRIPTION
1) this follows same method calls as devise_token_auth gem (https://github.com/codez/devise_token_auth/blob/1c4e1d0a439b3fade123810d1ccbc57e85df3832/app/controllers/devise_token_auth/concerns/set_user_by_token.rb#L79)
and sends proper request headers for batch requests like in this not yet accepted PR: https://github.com/lynndylanhurley/devise_token_auth/pull/703
Without that all the issues mentioned in PR above are present in highly async apps

2) additionally this makes sure that updated_at is a string