### PR TITLE
Fix another model name auth headers

### DIFF
--- a/lib/grape_devise_token_auth/auth_headers.rb
+++ b/lib/grape_devise_token_auth/auth_headers.rb
@@ -3,7 +3,7 @@ module GrapeDeviseTokenAuth
     extend Forwardable
 
     def initialize(warden, mapping, request_start, data)
-      @resource = warden.user(:user)
+      @resource = warden.user(mapping || :user)
       @request_start = request_start
       @data = data
     end

--- a/lib/grape_devise_token_auth/middleware.rb
+++ b/lib/grape_devise_token_auth/middleware.rb
@@ -4,7 +4,7 @@ module GrapeDeviseTokenAuth
 
     def initialize(app, resource_name)
       @app = app
-      @resource_name = resource_name
+      @resource_name = resource_name || app.options[:resource_class]
     end
 
     def call(env)

--- a/lib/grape_devise_token_auth/version.rb
+++ b/lib/grape_devise_token_auth/version.rb
@@ -1,3 +1,3 @@
 module GrapeDeviseTokenAuth
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end


### PR DESCRIPTION
The auth headers was not present in response if resource name was something different than `user`. Now it fetches resource class from options in `Middleware` and `AuthHeaders` use it in `initialize`. 